### PR TITLE
Add Free Shipping Notice to checkout cart

### DIFF
--- a/app/code/local/Erudyte/Shipping/Model/Observer.php
+++ b/app/code/local/Erudyte/Shipping/Model/Observer.php
@@ -12,16 +12,25 @@ class Erudyte_Shipping_Model_Observer
     public function displayFreeDeliveryNotice(Varien_Event_Observer $observer)
     {
         $shippingConfig = $this->getShippingConfig();
+        if (!$shippingConfig) {
+            return;
+        }
         if (!$shippingConfig['enabled']) {
             return;
         }
+
+        $checkoutSession = $this->getCheckoutSession();
+
         /** @var Mage_Sales_Model_Quote $quote */
-        $quote = $this->getCheckoutSession()->getQuote();
+        $quote = $checkoutSession->getQuote();
+        if (!$quote || $quote->getItemsCount() === 0) {
+            return;
+        }
         $freeDeliveryMinimum = $shippingConfig['free_delivery_minimum'];
         //get the quote subtotal
         $subtotal = $quote->getSubtotal();
         if ($message = $this->getFreeDeliveryMessage($freeDeliveryMinimum, $subtotal)) {
-            $this->getCheckoutSession()->addNotice($message);
+            $checkoutSession->addNotice($message);
         }
     }
 

--- a/app/code/local/Erudyte/Shipping/Model/Observer.php
+++ b/app/code/local/Erudyte/Shipping/Model/Observer.php
@@ -1,0 +1,64 @@
+<?php
+
+class Erudyte_Shipping_Model_Observer
+{
+    /**
+     *
+
+     * @param $observer
+     * @return $this
+     * @author Graham Crocker <graham.paul.crocker@gmail.com>
+     */
+    public function displayFreeDeliveryNotice(Varien_Event_Observer $observer)
+    {
+        $shippingConfig = $this->getShippingConfig();
+        if (!$shippingConfig['enabled']) {
+            return;
+        }
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = $this->getCheckoutSession()->getQuote();
+        $freeDeliveryMinimum = $shippingConfig['free_delivery_minimum'];
+        //get the quote subtotal
+        $subtotal = $quote->getSubtotal();
+        if ($message = $this->getFreeDeliveryMessage($freeDeliveryMinimum, $subtotal)) {
+            $this->getCheckoutSession()->addNotice($message);
+        }
+    }
+
+
+    /**
+     * @param float $freeDeliveryMinimum
+     * @param float $basketTotal
+     * @return string
+     * @author Graham Crocker <graham.paul.crocker@gmail.com>
+     */
+    protected function getFreeDeliveryMessage($freeDeliveryMinimum, $basketTotal)
+    {
+        $difference = $freeDeliveryMinimum - $basketTotal;
+        if (!((int) $difference > 0)) {
+            $display = "Spend another £$difference to qualify for Free Delivery";
+        } else {
+            $display = '';
+        }
+        return $display;
+    }
+
+    /**
+     * Potential Mocking area
+     *  @author Graham Crocker <graham.paul.crocker@gmail.com>
+     */
+    protected function getShippingConfig()
+    {
+        return Mage::getStoreConfig('shipping_rules/free_delivery');
+    }
+
+    /**
+     * Potential Mocking area
+     * @return Mage_Checkout_Model_Session
+     * @author Graham Crocker <graham.paul.crocker@gmail.com>
+     */
+    protected function getCheckoutSession()
+    {
+        return Mage::getSingleton('checkout/session');
+    }
+}

--- a/app/code/local/Erudyte/Shipping/Model/Observer.php
+++ b/app/code/local/Erudyte/Shipping/Model/Observer.php
@@ -9,7 +9,7 @@ class Erudyte_Shipping_Model_Observer
      * @return $this
      * @author Graham Crocker <graham.paul.crocker@gmail.com>
      */
-    public function displayFreeDeliveryNotice(Varien_Event_Observer $observer)
+    public function calculateFreeDelivery(Varien_Event_Observer $observer)
     {
         $shippingConfig = $this->getShippingConfig();
         if (!$shippingConfig) {

--- a/app/code/local/Erudyte/Shipping/etc/config.xml
+++ b/app/code/local/Erudyte/Shipping/etc/config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<config>
+    <modules>
+        <Erudyte_Shipping>
+            <version>0.1.0</version>
+        </Erudyte_Shipping>
+    </modules>
+    <default>
+        <shipping_rules>
+            <free_delivery>
+                <enabled>true</enabled>
+                <free_delivery_minimum>40.00</free_delivery_minimum>
+            </free_delivery>
+        </shipping_rules>
+    </default>
+    <global>
+        <models>
+            <Erudyte_Shipping>
+                <class>Erudyte_Shipping_Model</class>
+            </Erudyte_Shipping>
+        </models>
+    </global>
+    <frontend>
+        <events>
+            <controller_action_predispatch_checkout_cart_index>
+                <observers>
+                    <Erudyte_Shipping>
+                        <class>erudyte_shipping/observer</class>
+                        <method>calculateFreeDelivery</method>
+                    </Erudyte_Shipping>
+                </observers>
+            </controller_action_predispatch_checkout_cart_index>
+        </events>
+    </frontend>
+</config>

--- a/app/code/local/Erudyte/Shipping/etc/system.xml
+++ b/app/code/local/Erudyte/Shipping/etc/system.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <tabs>
+        <erudyte translate="label" module="Shipping">
+            <label>Shipping Rules</label>
+            <sort_order>100</sort_order>
+        </erudyte>
+    </tabs>
+    <sections>
+        <erudyte translate="label" module="Shipping">
+            <label>Erudyte</label>
+            <tab>erudyte</tab>
+            <sort_order>1000</sort_order>
+            <show_in_default>1</show_in_default>
+            <show_in_website>1</show_in_website>
+            <show_in_store>1</show_in_store>
+
+            <groups>
+                <erudyte_group translate="label" module="Shipping">
+                    <label>Shipping Rules</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>1000</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+
+                    <fields>
+                        <erudyte_input translate="label">
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </erudyte_input>
+                        <erudyte_select translate="label">
+                            <label>Minimum Free Delivery</label>
+                            <frontend_type>tet</frontend_type>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                        </erudyte_select>
+                    </fields>
+                </erudyte_group>
+            </groups>
+        </erudyte>
+    </sections>
+</config>

--- a/app/etc/modules/Erudyte_Shipping.xml
+++ b/app/etc/modules/Erudyte_Shipping.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config>
+    <modules>
+        <Erudyte_Shipping>
+            <active>true</active>
+            <codePool>local</codePool>
+        </Erudyte_Shipping>
+    </modules>
+</config>


### PR DESCRIPTION
Adds a Free shipping notice

A client has requested that we add to the shopping basket page of their website a calculator which lets the user know how much more they need to add to their basket in order to obtain free delivery.
We would like to create a custom module which facilitates this including adding settings in the admin panel for the free
delivery minimum limit and applying the calculation to the shopping basket.
Copy to say “Spend another £x.xx to qualify for Free Delivery”
